### PR TITLE
Change schema-manger to retry database connection indefinitely 

### DIFF
--- a/schema-manager/src/main.rs
+++ b/schema-manager/src/main.rs
@@ -215,7 +215,9 @@ fn run(log: &Logger) -> Result<(), Box<dyn std::error::Error>> {
 
     let pool_opts = ConnectionPoolOptions {
         max_connections: Some(1),
-        claim_timeout: Some(10000),
+        // Set the claim timeout to None, which causes cueball to use the condvar wait call with no timeout,
+        // schema-manager should continually retry for a postgres connection.
+        claim_timeout: None,
         log: Some(log.new(o!(
             "component" => "CueballConnectionPool"
         ))),


### PR DESCRIPTION
MANTA-4924: remove the claim_timeout paramater to cueball connection pool, which causes it to use the convar wait call instead of wait_timeout, so it should continue to retry as long as the exponential backoff calls continue.