### PR TITLE
MANTA-4924 Timing issue: schema-manager is blocked from connecting to buckets-postgres database by waferlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,5 @@ logfile
 .coverage_data
 cover_html
 *.tar.bz2
-smf/manifests/*.xml
 sapi_manifests/registrar/template
-sdc/sapi_manifests/registrar/template
 config.toml

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ NAME = manta-buckets-mdapi
 
 RUST_CODE = 1
 
-SMF_MANIFESTS_IN = smf/manifests/buckets-mdapi.xml.in
+SMF_MANIFESTS = smf/manifests/buckets-mdapi.xml smf/manifests/buckets-mdapi-setup.xml
 
 ENGBLD_USE_BUILDIMAGE =	true
 ENGBLD_REQUIRE := 	$(shell git submodule update --init deps/eng)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 NAME = manta-buckets-mdapi

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -92,22 +92,12 @@ function setup_buckets_mdapi {
     svcadm enable -s config-agent
     svcadm restart registrar
 
+    svccfg import /opt/smartdc/buckets-mdapi/smf/manifests/buckets-mdapi-setup.xml
     svccfg import /opt/smartdc/buckets-mdapi/smf/manifests/buckets-mdapi.xml
-    svcadm enable buckets-mdapi || fatal "unable to start buckets-mdapi"
 }
 
-#
-# manta_setup_buckets_mdapi_schemas: run the schema-manager to define the
-# buckets-mdapi schemas on the associated shards if they do not yet exist.
-#
-function manta_setup_buckets_mdapi_schemas {
-    if [[ -x /opt/smartdc/buckets-mdapi/bin/schema-manager ]] ; then
-        echo "Setting up buckets-mdapi schemas"
-        /opt/smartdc/buckets-mdapi/bin/schema-manager || echo "unable to set up buckets-mdapi schemas"
-    else
-        fatal "schema-manager executable not found."
-    fi
-}
+
+# ---- mainline
 
 source ${DIR}/scripts/util.sh
 source ${DIR}/scripts/services.sh
@@ -125,7 +115,6 @@ manta_ensure_zk
 echo "setting up buckets-ddapi"
 get_sapi_config
 setup_buckets_mdapi
-manta_setup_buckets_mdapi_schemas
 
 manta_common_setup_end
 

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -7,7 +7,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 export PS4='[\D{%FT%TZ}] ${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'

--- a/smf/manifests/buckets-mdapi-setup.xml
+++ b/smf/manifests/buckets-mdapi-setup.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<!--
+    Copyright 2020 Joyent, Inc.
+-->
+
+<service_bundle type="manifest" name="buckets-mdapi-setup">
+    <service name="manta/application/buckets-mdapi-setup" type="service" version="1">
+
+        <create_default_instance enabled="true" />
+
+        <dependency name="network" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/network/physical" />
+        </dependency>
+        <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/system/filesystem/local" />
+        </dependency>
+        <dependency name="mdata" grouping="require_all" restart_on="none" type="service">
+            <service_fmri value="svc:/smartdc/mdata:execute" />
+        </dependency>
+        <dependency name="config-agent" grouping="optional_all" restart_on="none" type="service">
+            <service_fmri value="svc:/smartdc/application/config-agent" />
+        </dependency>
+
+        <exec_method type="method" name="start" timeout_seconds="0"
+                     exec="/opt/smartdc/buckets-mdapi/smf/method/buckets-mdapi-setup"/>
+        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="30" />
+
+        <property_group name='startd' type='framework'>
+            <propval name='duration' type='astring' value='transient'/>
+        </property_group>
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Manta Buckets Metadata API Setup</loctext>
+            </common_name>
+        </template>
+    </service>
+</service_bundle>

--- a/smf/manifests/buckets-mdapi.xml
+++ b/smf/manifests/buckets-mdapi.xml
@@ -7,7 +7,7 @@
 -->
 
 <!--
-    Copyright 2019 Joyent, Inc.
+    Copyright 2020 Joyent, Inc.
 -->
 
 <service_bundle type="manifest" name="buckets-mdapi">
@@ -35,11 +35,11 @@
             <service_fmri value="svc:/smartdc/mdata:execute" />
         </dependency>
 
-        <dependency name="config-agent"
+        <dependency name="buckets-mdapi-setup"
                     grouping="optional_all"
                     restart_on="none"
                     type="service">
-            <service_fmri value="svc:/smartdc/application/config-agent" />
+            <service_fmri value="svc:/manta/application/buckets-mdapi-setup" />
         </dependency>
 
         <exec_method type="method" name="start" timeout_seconds="10"

--- a/smf/method/buckets-mdapi-setup
+++ b/smf/method/buckets-mdapi-setup
@@ -6,7 +6,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 #
@@ -29,7 +29,7 @@ function setup_run_schema_manager {
     #
     # This relies on (a) the buckets-mdplacement service being up and ready,
     # and (b) the buckets-postgres cluster for this shard being ready and
-    # accessible. The later can take a while:
+    # accessible. The latter can take a while:
     #
     # - Access to the postgres cluster is guarded by the "waferlock" service
     #   in the postgres zones. It needs to notice the IP of this newly

--- a/smf/method/buckets-mdapi-setup
+++ b/smf/method/buckets-mdapi-setup
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+#
+# Copyright 2019 Joyent, Inc.
+#
+
+#
+# "buckets-mdapi-setup" service for doing one-time initial setup work that
+# cannot be done in "boot/setup.sh". The "buckets-mdapi" service will
+# depend on this so that it need not worry about being run before the postgres
+# DB is setup.
+#
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+
+. /lib/svc/share/smf_include.sh
+
+SENTINEL=/var/svc/.ran-buckets-mdapi-setup
+
+function setup_run_schema_manager {
+    # Run the schema-manager to setup the buckets-mdapi database in postgres.
+    #
+    # This relies on (a) the buckets-mdplacement service being up and ready,
+    # and (b) the buckets-postgres cluster for this shard being ready and
+    # accessible. The later can take a while:
+    #
+    # - Access to the postgres cluster is guarded by the "waferlock" service
+    #   in the postgres zones. It needs to notice the IP of this newly
+    #   provisioned buckets-mdapi instance and allow it. On a slow system or
+    #   with unlucky polling intervals, this can take longer than the 300s
+    #   mdata:execute timeout.
+    # - Theoretically buckets-postgres could be unexpectedly down, or not yet
+    #   setup.
+    /opt/smartdc/buckets-mdapi/bin/schema-manager
+}
+
+
+# ---- mainline
+
+if [[ ! -e ${SENTINEL} ]]; then
+    setup_run_schema_manager
+    touch $SENTINEL
+fi
+
+exit $SMF_EXIT_OK


### PR DESCRIPTION
Add a buckets-mdapi-setup SMF service that runs before "buckets-mdapi"
and ensures that schema-manager has been run once. Doing this in a
separate service ensures we don't hit the mdata:execute 300s timeout
under which boot/setup.sh is running.