### PR TITLE
Bump up the cueball dependency to 0.3.2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cueball 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cueball 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cueball-manatee-primary-resolver 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cueball-postgres-connection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cueball-static-resolver 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -386,14 +386,14 @@ dependencies = [
 
 [[package]]
 name = "cueball"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backoff 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-stdlog 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -408,7 +408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cueball 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cueball 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -427,7 +427,7 @@ name = "cueball-manatee-primary-resolver"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cueball 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cueball 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -447,7 +447,7 @@ name = "cueball-postgres-connection"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cueball 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cueball 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.16.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres-protocol 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -462,7 +462,7 @@ name = "cueball-static-resolver"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cueball 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cueball 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -470,7 +470,7 @@ name = "cueball-tcp-stream-connection"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cueball 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cueball 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1524,18 +1524,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.2"
 source = "git+https://github.com/rust-random/rand#19b5a3e85cae272602abb51b5cae511980fff47c"
 dependencies = [
@@ -1544,6 +1532,18 @@ dependencies = [
  "rand_chacha 0.2.1 (git+https://github.com/rust-random/rand)",
  "rand_core 0.5.1 (git+https://github.com/rust-random/rand)",
  "rand_hc 0.2.0 (git+https://github.com/rust-random/rand)",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1557,21 +1557,20 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.2.1"
 source = "git+https://github.com/rust-random/rand#19b5a3e85cae272602abb51b5cae511980fff47c"
 dependencies = [
  "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (git+https://github.com/rust-random/rand)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1589,8 +1588,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand_core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.5.1"
+source = "git+https://github.com/rust-random/rand#19b5a3e85cae272602abb51b5cae511980fff47c"
 dependencies = [
  "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1598,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "rand_core"
 version = "0.5.1"
-source = "git+https://github.com/rust-random/rand#19b5a3e85cae272602abb51b5cae511980fff47c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1624,7 +1623,7 @@ name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1884,7 +1883,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmd_lib 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "cueball 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cueball 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cueball-dns-resolver 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cueball-manatee-primary-resolver 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cueball-postgres-connection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2189,7 +2188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2662,7 +2661,7 @@ name = "utils"
 version = "0.3.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cueball 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cueball 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cueball-manatee-primary-resolver 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cueball-postgres-connection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2814,7 +2813,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-"checksum cueball 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f197f9a6d1d6a10d3fc69baf11a0b51c37cd068da7961f8027596ae158581d2"
+"checksum cueball 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9373ca10b1e7984188f89aec1dacdef139734f057ed88e3e739229a581225f"
 "checksum cueball-dns-resolver 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6d3dafe6f3730f2f17171c63fb9ef62a02a25ce41252d9df5f3d3663900b682"
 "checksum cueball-manatee-primary-resolver 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0f3453adce3f9c0a0f84ef7dad8a68ff1e6df331331c68612c0a376b207a74fa"
 "checksum cueball-postgres-connection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a570f90272c004943735c6e0ad3aa16cd04ee0d92d75a89b8d0138dabf08ade1"
@@ -2941,15 +2940,15 @@ dependencies = [
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum radix_trie 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3d3681b28cd95acfb0560ea9441f82d6a4504fa3b15b97bd7b6e952131820e95"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-"checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand 0.7.2 (git+https://github.com/rust-random/rand)" = "<none>"
+"checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-"checksum rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d"
 "checksum rand_chacha 0.2.1 (git+https://github.com/rust-random/rand)" = "<none>"
+"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
-"checksum rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"
 "checksum rand_core 0.5.1 (git+https://github.com/rust-random/rand)" = "<none>"
+"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_hc 0.2.0 (git+https://github.com/rust-random/rand)" = "<none>"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"

--- a/buckets-mdapi/Cargo.toml
+++ b/buckets-mdapi/Cargo.toml
@@ -14,7 +14,7 @@ hyper = {version = "0.12.25"}
 md5 = "0.5.0"
 postgres = {version = "0.16.0-rc.1", features=["with-chrono-0_4", "with-serde_json-1", "with-uuid-0_7"]}
 prometheus = "0.5.0"
-cueball = "0.3.0"
+cueball = "0.3.2"
 cueball-manatee-primary-resolver = "0.3.0"
 cueball-postgres-connection = "0.3.0"
 rust_fast = { git = "https://github.com/joyent/rust-fast", tag = "v0.1.1" }

--- a/schema-manager/Cargo.toml
+++ b/schema-manager/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 clap = "2.32"
 cmd_lib = "0.7.8"
-cueball = "0.3.0"
+cueball = "0.3.2"
 cueball-manatee-primary-resolver = "0.3.0"
 cueball-postgres-connection = "0.3.0"
 cueball-dns-resolver = "0.3.0"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 clap = "2.32"
-cueball = "0.3.0"
+cueball = "0.3.2"
 cueball-manatee-primary-resolver = "0.3.0"
 cueball-postgres-connection = "0.3.0"
 itertools = "0.8.2"


### PR DESCRIPTION
New version of cueball that addresses MANTA-4989.