### PR TITLE
MANTA-4119 Create helpful functions to assist operators in manually querying the database

### DIFF
--- a/migrations/public/0001-0001-helper-functions.sql
+++ b/migrations/public/0001-0001-helper-functions.sql
@@ -1,0 +1,87 @@
+START TRANSACTION;
+
+SELECT execute($$
+
+CREATE OR REPLACE FUNCTION list_all_objects(lmt int DEFAULT 100)
+RETURNS TABLE(schma text, id uuid, name text, owner uuid, bucket_id uuid, created
+timestamptz, modified timestamptz, content_length
+bigint, content_md5 bytea, content_type text, headers hstore, sharks text[],
+properties jsonb) AS $$
+DECLARE
+  schema RECORD;
+BEGIN
+  FOR schema IN EXECUTE
+      'SELECT schema_name FROM information_schema.schemata WHERE left(schema_name, 13) = ''manta_bucket_'''
+  LOOP
+    RETURN QUERY EXECUTE
+      format('SELECT ''%I'', id, name, owner, bucket_id, created, modified, content_length, content_md5::bytea, content_type, headers, sharks, properties FROM %I.manta_bucket_object LIMIT %L', schema.schema_name, schema.schema_name, lmt);
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION list_all_buckets(lmt int DEFAULT 100)
+RETURNS TABLE(schma text, id uuid, name text, owner uuid, created timestamptz) AS $$
+DECLARE
+  schema RECORD;
+BEGIN
+  FOR schema IN EXECUTE
+      'SELECT schema_name FROM information_schema.schemata WHERE left(schema_name, 13) = ''manta_bucket_'''
+  LOOP
+    RETURN QUERY EXECUTE
+      format('SELECT ''%I'', id, name, owner, created FROM %I.manta_bucket LIMIT %L', schema.schema_name, schema.schema_name, lmt);
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bucket_listing(o_id uuid, b_id uuid, lmt int DEFAULT 100)
+RETURNS TABLE(schma text, id uuid, name text, owner uuid, bucket_id uuid, created
+timestamptz, modified timestamptz, content_length
+bigint, content_md5 bytea, content_type text, headers hstore, sharks text[],
+properties jsonb) AS $$
+DECLARE
+  schema RECORD;
+BEGIN
+  FOR schema IN EXECUTE
+      'SELECT schema_name FROM information_schema.schemata WHERE left(schema_name, 13) = ''manta_bucket_'''
+  LOOP
+    RETURN QUERY EXECUTE
+      format('SELECT ''%I'', id, name, owner, bucket_id, created, modified, content_length, content_md5::bytea, content_type, headers, sharks, properties FROM %I.manta_bucket_object WHERE owner = %L and
+bucket_id = %L LIMIT %L', schema.schema_name, schema.schema_name, o_id, b_id, lmt);
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION list_all_deleted_objects(lmt int DEFAULT 1000)
+RETURNS TABLE(schma text, id uuid, owner uuid, bucket_id uuid, name text, created timestamptz, modified timestamptz, content_length bigint, content_md5 bytea, content_type text, headers hstore, sharks text[], properties jsonb) AS $$
+DECLARE
+        schema RECORD;
+BEGIN
+      FOR schema IN EXECUTE
+          'SELECT schema_name FROM information_schema.schemata WHERE left(schema_name, 13) = ''manta_bucket_'''
+      LOOP
+           RETURN QUERY EXECUTE
+                  format('SELECT ''%I'', id, owner, bucket_id, name, created, modified, content_length, content_md5, content_type, headers, sharks, properties FROM %I.manta_bucket_deleted_object LIMIT %L', schema.schema_name, schema.schema_name, lmt);
+      END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION list_all_deleted_buckets(lmt int DEFAULT 100)
+RETURNS TABLE(schma text, id uuid, name text, owner uuid, created timestamptz) AS $$
+DECLARE
+  schema RECORD;
+BEGIN
+  FOR schema IN EXECUTE
+      'SELECT schema_name FROM information_schema.schemata WHERE left(schema_name, 13) = ''manta_bucket_'''
+  LOOP
+    RETURN QUERY EXECUTE
+      format('SELECT ''%I'', id, name, owner, created FROM %I.manta_bucket_deleted_bucket LIMIT %L', schema.schema_name, schema.schema_name, lmt);
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+INSERT INTO migrations (major, minor, note) VALUES (1, 1, 'Create helper functions for operators');
+
+$$)
+WHERE NOT public_migration_exists(1, 1);
+
+COMMIT;

--- a/migrations/public/0001-0001-helper-functions.sql
+++ b/migrations/public/0001-0001-helper-functions.sql
@@ -6,7 +6,7 @@ CREATE OR REPLACE FUNCTION list_all_objects(lmt int DEFAULT 100)
 RETURNS TABLE(schma text, id uuid, name text, owner uuid, bucket_id uuid, created
 timestamptz, modified timestamptz, content_length
 bigint, content_md5 bytea, content_type text, headers hstore, sharks text[],
-properties jsonb) AS $$
+properties jsonb) AS $INNER$
 DECLARE
   schema RECORD;
 BEGIN
@@ -17,10 +17,10 @@ BEGIN
       format('SELECT ''%I'', id, name, owner, bucket_id, created, modified, content_length, content_md5::bytea, content_type, headers, sharks, properties FROM %I.manta_bucket_object LIMIT %L', schema.schema_name, schema.schema_name, lmt);
   END LOOP;
 END;
-$$ LANGUAGE plpgsql;
+$INNER$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION list_all_buckets(lmt int DEFAULT 100)
-RETURNS TABLE(schma text, id uuid, name text, owner uuid, created timestamptz) AS $$
+RETURNS TABLE(schma text, id uuid, name text, owner uuid, created timestamptz) AS $INNER$
 DECLARE
   schema RECORD;
 BEGIN
@@ -31,13 +31,13 @@ BEGIN
       format('SELECT ''%I'', id, name, owner, created FROM %I.manta_bucket LIMIT %L', schema.schema_name, schema.schema_name, lmt);
   END LOOP;
 END;
-$$ LANGUAGE plpgsql;
+$INNER$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION bucket_listing(o_id uuid, b_id uuid, lmt int DEFAULT 100)
 RETURNS TABLE(schma text, id uuid, name text, owner uuid, bucket_id uuid, created
 timestamptz, modified timestamptz, content_length
 bigint, content_md5 bytea, content_type text, headers hstore, sharks text[],
-properties jsonb) AS $$
+properties jsonb) AS $INNER$
 DECLARE
   schema RECORD;
 BEGIN
@@ -49,10 +49,10 @@ BEGIN
 bucket_id = %L LIMIT %L', schema.schema_name, schema.schema_name, o_id, b_id, lmt);
   END LOOP;
 END;
-$$ LANGUAGE plpgsql;
+$INNER$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION list_all_deleted_objects(lmt int DEFAULT 1000)
-RETURNS TABLE(schma text, id uuid, owner uuid, bucket_id uuid, name text, created timestamptz, modified timestamptz, content_length bigint, content_md5 bytea, content_type text, headers hstore, sharks text[], properties jsonb) AS $$
+RETURNS TABLE(schma text, id uuid, owner uuid, bucket_id uuid, name text, created timestamptz, modified timestamptz, content_length bigint, content_md5 bytea, content_type text, headers hstore, sharks text[], properties jsonb) AS $INNER$
 DECLARE
         schema RECORD;
 BEGIN
@@ -63,10 +63,10 @@ BEGIN
                   format('SELECT ''%I'', id, owner, bucket_id, name, created, modified, content_length, content_md5, content_type, headers, sharks, properties FROM %I.manta_bucket_deleted_object LIMIT %L', schema.schema_name, schema.schema_name, lmt);
       END LOOP;
 END;
-$$ LANGUAGE plpgsql;
+$INNER$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION list_all_deleted_buckets(lmt int DEFAULT 100)
-RETURNS TABLE(schma text, id uuid, name text, owner uuid, created timestamptz) AS $$
+RETURNS TABLE(schma text, id uuid, name text, owner uuid, created timestamptz) AS $INNER$
 DECLARE
   schema RECORD;
 BEGIN
@@ -77,7 +77,7 @@ BEGIN
       format('SELECT ''%I'', id, name, owner, created FROM %I.manta_bucket_deleted_bucket LIMIT %L', schema.schema_name, schema.schema_name, lmt);
   END LOOP;
 END;
-$$ LANGUAGE plpgsql;
+$INNER$ LANGUAGE plpgsql;
 
 INSERT INTO migrations (major, minor, note) VALUES (1, 1, 'Create helper functions for operators');
 


### PR DESCRIPTION
This PR adds some functions that can be used by operators to query information about the data on a manta metadata shard. This includes the following functions:

* `list_all_objects`: List all the objects on the shard. This queries the `manta_bucket_object` table of each vnode on the shard.
* `list_all_buckets`: List all the buckets on the shard. This queries the `manta_bucket` table of each vnode on the shard.
* `bucket_listing`: List all the objects from a particular bucket for a given account on the shard. This function queries the `manta_bucket_object` table and requires the UUID of an account owner and the UUID of a bucket as input.
* `list_all_deleted_objects`: List all the deleted objects. This function queries the `manta_bucket_deleted_object` table of each vnode on the shard.
* `list_all_deleted_buckets`: List all the deleted buckets. This function queries the `manta_bucket_deleted_bucket` table of each vnode on the shard.