### PR TITLE
MANTA-5114 buckets getgcbatch returns > 1000 results

### DIFF
--- a/migrations/public/0001-0002-limit-get-garbage-function-results.sql
+++ b/migrations/public/0001-0002-limit-get-garbage-function-results.sql
@@ -1,0 +1,33 @@
+START TRANSACTION;
+
+SELECT execute($$
+
+CREATE OR REPLACE FUNCTION get_garbage(lmt int DEFAULT 1000)
+RETURNS TABLE(schma text, id uuid, owner uuid, bucket_id uuid, name text, created timestamptz, modified timestamptz, content_length bigint, content_md5 bytea, content_type text, headers hstore, sharks text[], properties jsonb) AS $GARBAGE$
+DECLARE
+        schema RECORD;
+        row_count int;
+        running_count int := 0;
+ BEGIN
+      FOR schema IN EXECUTE
+          'SELECT schema_name FROM information_schema.schemata WHERE left(schema_name, 13) = ''manta_bucket_'''
+      LOOP
+           RETURN QUERY EXECUTE
+                  format('SELECT ''%I'', id, owner, bucket_id, name, created, modified, content_length, content_md5, content_type, headers, sharks, properties FROM %I.manta_bucket_deleted_object LIMIT %L', schema.schema_name, schema.schema_name, lmt - running_count);
+
+           GET DIAGNOSTICS row_count = ROW_COUNT;
+           running_count := running_count + row_count;
+
+           IF running_count >= lmt THEN
+              RETURN;
+           END IF;
+      END LOOP;
+END;
+$GARBAGE$ LANGUAGE plpgsql;
+
+INSERT INTO migrations (major, minor, note) VALUES (1, 2, 'Correct error in limiting results from get_garbage function');
+
+$$)
+WHERE NOT public_migration_exists(1, 2);
+
+COMMIT;


### PR DESCRIPTION
This change just updates the body of the `get_garbage` function created in a previous migration. In #49 I accidentally used minor version 4 for the new migration there. Normally we want all migration versions to increase so that order-based application assumptions can be made; however, in this case I am using minor version 2 because the only dependency is on minor version 1. This is a special circumstance and should only be repeated for minor version 3 with care.