### PR TITLE
MANTA-5219 Configure metricPorts in buckets API components by default

### DIFF
--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -79,7 +79,7 @@ function setup_buckets_mdapi {
     port=$(json metadata.BUCKETS_MDAPI_SERVER_PORT <<< "${SAPI_CONFIG}")
     [[ -n "${port}" ]] || port='2030'
     metrics_port=$(json metadata.BUCKETS_MDAPI_METRICS_PORT <<< "${SAPI_CONFIG}")
-    [[ -n "${metrics_port}" ]] || port='3020'
+    [[ -n "${metrics_port}" ]] || metrics_port='3020'
 
     #
     # Regenerate the registrar config with the real port included

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -99,7 +99,7 @@ function setup_buckets_mdapi {
     svccfg import /opt/smartdc/buckets-mdapi/smf/manifests/buckets-mdapi-setup.xml
     svccfg import /opt/smartdc/buckets-mdapi/smf/manifests/buckets-mdapi.xml
 
-    mdata-put metricPorts $(echo "${metrics_port}")
+    mdata-put metricPorts "${metrics_port}"
 }
 
 

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -68,14 +68,18 @@ function get_sapi_config {
 
 function setup_buckets_mdapi {
     local port
+    local metrics_port
     local RTPL
 
     #
-    # The default port value here must be kept in sync with the default value of
-    # BUCKETS_MDAPI_SERVER_PORT in sapi_manifests/buckets-mdapi/template and the Makefile.
+    # The default port values here must be kept in sync with the default value of
+    # BUCKETS_MDAPI_SERVER_PORT and BUCKETS_MDAPI_METRICS_PORT in
+    # sapi_manifests/buckets-mdapi/template and the Makefile.
     #
     port=$(json metadata.BUCKETS_MDAPI_SERVER_PORT <<< "${SAPI_CONFIG}")
     [[ -n "${port}" ]] || port='2030'
+    metrics_port=$(json metadata.BUCKETS_MDAPI_METRICS_PORT <<< "${SAPI_CONFIG}")
+    [[ -n "${metrics_port}" ]] || port='3020'
 
     #
     # Regenerate the registrar config with the real port included
@@ -94,6 +98,8 @@ function setup_buckets_mdapi {
 
     svccfg import /opt/smartdc/buckets-mdapi/smf/manifests/buckets-mdapi-setup.xml
     svccfg import /opt/smartdc/buckets-mdapi/smf/manifests/buckets-mdapi.xml
+
+    mdata-put metricPorts $(echo "${metrics_port}")
 }
 
 


### PR DESCRIPTION
Tested the change by reprovisioning a bucket-mdapi instance in a lab environment to the image with this PR and confirming that `mdata-get metricPorts` return the correct values.

Also tested with a custom metrics port
```
sapiadm update $(sdc-sapi /services?name=buckets-mdapi | json -H 0.uuid) metadata.BUCKETS_MDAPI_METRICS_PORT=4020
```
and verified that the new port number was picked up after rerunning `setup.sh`.